### PR TITLE
deterministic apk provided by github

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ script:
   - echo icsopenvpnDebugSign=true > ~/.gradle/gradle.properties
   # Building one variant is enough and already takes quite a long time...
   - ./gradlew assembleUiRelease
+  - find . -name *.apk
 
 before_script:
   # Install packages
@@ -51,4 +52,14 @@ before_script:
   - yes | sdkmanager 'platforms;android-28'
 
   - export PATH=$PATH:${ANDROID_NDK_HOME}
+
+deploy:
+  provider: releases
+  api_key: ${api_key}
+  file_glob: true
+  file:
+    - "./main/build/outputs/apk/ui/release/main-ui-x86*.apk"
+  skip_cleanup: true
+  on:
+    tags: true
 


### PR DESCRIPTION
Now we have a deterministic build and a comprehensible apk, because the release has the apk too

eg https://github.com/hannesa2/ics-openvpn/releases

<img width="482" alt="image" src="https://user-images.githubusercontent.com/3314607/82112775-9919bc80-9750-11ea-8854-1b20330074ab.png">

And we can download it with 
`wget https://github.com/hannesa2/ics-openvpn/releases/download/v0.7.15.test/main-ui-x86_64-release.apk`
instead of push to git

To make it work on your repo, you need a token or you use temporary my repo

![image](https://user-images.githubusercontent.com/3314607/82112299-d760ad00-974b-11ea-8ba8-867c1f40796a.png)
